### PR TITLE
Collection of ID

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,14 +18,14 @@ GEM
       rake
     rake (0.9.2.2)
     redis (3.0.7)
-    rspec (2.10.0)
-      rspec-core (~> 2.10.0)
-      rspec-expectations (~> 2.10.0)
-      rspec-mocks (~> 2.10.0)
-    rspec-core (2.10.1)
-    rspec-expectations (2.10.0)
+    rspec (2.11.0)
+      rspec-core (~> 2.11.0)
+      rspec-expectations (~> 2.11.0)
+      rspec-mocks (~> 2.11.0)
+    rspec-core (2.11.1)
+    rspec-expectations (2.11.3)
       diff-lcs (~> 1.1.3)
-    rspec-mocks (2.10.1)
+    rspec-mocks (2.11.3)
 
 PLATFORMS
   ruby
@@ -37,4 +37,4 @@ DEPENDENCIES
   mocha (= 0.9.8)
   redis
   rollout!
-  rspec (~> 2.10.0)
+  rspec (~> 2.11.0)

--- a/lib/rollout.rb
+++ b/lib/rollout.rb
@@ -178,9 +178,7 @@ class Rollout
   end
 
   def collections
-    retrieve_from_storage(collection_key).each_with_object({}) do |collection_name, obj|
-      obj[collection_name.to_sym] = @storage.get(collection_key(collection_name))
-    end
+    retrieve_users_from_key(collection_key)
   end
 
   def retrieve_from_storage(key)
@@ -192,9 +190,7 @@ class Rollout
   end
 
   def feature_collections(feature)
-    retrieve_from_storage(collection_feature_key(feature)).each_with_object({}) do |collection_name, obj|
-      obj[collection_name.to_sym] = @storage.get(collection_key(collection_name))
-    end
+    retrieve_users_from_key(collection_feature_key(feature))
   end
 
   def active?(feature, user = nil)
@@ -268,6 +264,12 @@ class Rollout
 
     def collection_feature_key(feature)
       "collections_for:#{feature}"
+    end
+
+    def retrieve_users_from_key(storage_key)
+      retrieve_from_storage(storage_key).each_with_object({}) do |collection_name, obj|
+        obj[collection_name.to_sym] = @storage.get(collection_key(collection_name))
+      end
     end
 
     def with_feature(feature)

--- a/lib/rollout.rb
+++ b/lib/rollout.rb
@@ -167,7 +167,7 @@ class Rollout
   end
 
   def define_id_collection(name, ids = [])
-    @storage.set("collection:#{name}", ids.join(","))
+    @storage.set(collection_key(name), ids.join(","))
     @storage.set(collection_key, (collections.keys | [name.to_sym]).join(","))
   end
 
@@ -178,7 +178,7 @@ class Rollout
   end
 
   def collections
-    Hash[*retrieve_from_storage(collection_key).map{ |collect| [ collect.to_sym, @storage.get("collection:#{collect}") ] }.flatten]
+    Hash[*retrieve_from_storage(collection_key).map{ |collect| [ collect.to_sym, @storage.get(collection_key(collect)) ] }.flatten]
   end
 
   def retrieve_from_storage(key)
@@ -190,7 +190,7 @@ class Rollout
   end
 
   def feature_collections(feature)
-    Hash[*retrieve_from_storage(collection_feature_key(feature)).map{ |collect| [ collect.to_sym, @storage.get("collection:#{collect}") ] }.flatten]
+    Hash[*retrieve_from_storage(collection_feature_key(feature)).map{ |collect| [ collect.to_sym, @storage.get(collection_key(collect)) ] }.flatten]
   end
 
   def active?(feature, user = nil)

--- a/lib/rollout.rb
+++ b/lib/rollout.rb
@@ -178,7 +178,9 @@ class Rollout
   end
 
   def collections
-    Hash[*retrieve_from_storage(collection_key).map{ |collect| [collect.to_sym, @storage.get(collection_key(collect))] }.flatten]
+    retrieve_from_storage(collection_key).each_with_object({}) do |collection_name, obj|
+      obj[collection_name.to_sym] = @storage.get(collection_key(collection_name))
+    end
   end
 
   def retrieve_from_storage(key)
@@ -190,7 +192,9 @@ class Rollout
   end
 
   def feature_collections(feature)
-    Hash[*retrieve_from_storage(collection_feature_key(feature)).map{ |collect| [ collect.to_sym, @storage.get(collection_key(collect)) ] }.flatten]
+    retrieve_from_storage(collection_feature_key(feature)).each_with_object({}) do |collection_name, obj|
+      obj[collection_name.to_sym] = @storage.get(collection_key(collection_name))
+    end
   end
 
   def active?(feature, user = nil)

--- a/lib/rollout.rb
+++ b/lib/rollout.rb
@@ -178,7 +178,7 @@ class Rollout
   end
 
   def collections
-    Hash[*retrieve_from_storage(collection_key).map{ |collect| [ collect.to_sym, @storage.get(collection_key(collect)) ] }.flatten]
+    Hash[*retrieve_from_storage(collection_key).map{ |collect| [collect.to_sym, @storage.get(collection_key(collect))] }.flatten]
   end
 
   def retrieve_from_storage(key)

--- a/lib/rollout.rb
+++ b/lib/rollout.rb
@@ -166,7 +166,7 @@ class Rollout
     @groups[group.to_sym] = block
   end
 
-  def define_id_collection(name, ids=[])
+  def define_id_collection(name, ids = [])
     @storage.set("collection:#{name}", ids.join(","))
     @storage.set(collection_key, (collections.keys | [name.to_sym]).join(","))
   end

--- a/lib/rollout.rb
+++ b/lib/rollout.rb
@@ -55,7 +55,8 @@ class Rollout
         id = user_id(user)
         user_in_percentage?(id) ||
           user_in_active_users?(id) ||
-            user_in_active_group?(user, rollout)
+            user_in_active_group?(user, rollout) ||
+              user_in_collections?(id, rollout)
       end
     end
 
@@ -98,6 +99,12 @@ class Rollout
       def user_in_active_group?(user, rollout)
         @groups.any? do |g|
           rollout.active_in_group?(g, user)
+        end
+      end
+
+      def user_in_collections?(id, rollout)
+        rollout.feature_collections(@name).keys.any? do |collection|
+          rollout.active_in_collection?(collection, id)
         end
       end
   end
@@ -159,6 +166,29 @@ class Rollout
     @groups[group.to_sym] = block
   end
 
+  def define_id_collection(name, ids=[])
+    @storage.set("collection:#{name}", ids.join(","))
+    @storage.set(collection_key, (collections.keys | [name.to_sym]).join(","))
+  end
+
+  def add_collection_to_feature(collection, feature)
+    with_feature(feature) do |feature|
+      @storage.set(collection_feature_key(feature.name), (feature_collections(feature.name).keys | [ collection.to_sym]).join(","))
+    end
+  end
+
+  def collections
+    Hash[*(@storage.get(collection_key) || "").split(",").map{ |collect| [ collect.to_sym, @storage.get("collection:#{collect}") ] }.flatten]
+  end
+
+  def ids_from_collection(collection)
+    (@storage.get(collection_key(collection)) || "").split(",")
+  end
+
+  def feature_collections(feature)
+    Hash[*(@storage.get(collection_feature_key(feature)) || "").split(",").map{ |collect| [ collect.to_sym, @storage.get("collection:#{collect}") ] }.flatten]
+  end
+
   def active?(feature, user = nil)
     feature = get(feature)
     feature.active?(self, user)
@@ -179,6 +209,11 @@ class Rollout
   def active_in_group?(group, user)
     f = @groups[group.to_sym]
     f && f.call(user)
+  end
+
+  def active_in_collection?(collection, id)
+    f = collections[collection.to_sym]
+    f && f.split(",").include?(id.to_s)
   end
 
   def get(feature)
@@ -217,6 +252,14 @@ class Rollout
 
     def features_key
       "feature:__features__"
+    end
+
+    def collection_key(collection="__collections__")
+      "collection:#{collection}"
+    end
+
+    def collection_feature_key(feature)
+      "collections_for:#{feature}"
     end
 
     def with_feature(feature)

--- a/lib/rollout.rb
+++ b/lib/rollout.rb
@@ -178,15 +178,19 @@ class Rollout
   end
 
   def collections
-    Hash[*(@storage.get(collection_key) || "").split(",").map{ |collect| [ collect.to_sym, @storage.get("collection:#{collect}") ] }.flatten]
+    Hash[*retrieve_from_storage(collection_key).map{ |collect| [ collect.to_sym, @storage.get("collection:#{collect}") ] }.flatten]
+  end
+
+  def retrieve_from_storage(key)
+    (@storage.get(key) || "").split(',')
   end
 
   def ids_from_collection(collection)
-    (@storage.get(collection_key(collection)) || "").split(",")
+    retrieve_from_storage(collection_key(collection))
   end
 
   def feature_collections(feature)
-    Hash[*(@storage.get(collection_feature_key(feature)) || "").split(",").map{ |collect| [ collect.to_sym, @storage.get("collection:#{collect}") ] }.flatten]
+    Hash[*retrieve_from_storage(collection_feature_key(feature)).map{ |collect| [ collect.to_sym, @storage.get("collection:#{collect}") ] }.flatten]
   end
 
   def active?(feature, user = nil)

--- a/rollout.gemspec
+++ b/rollout.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_development_dependency "rspec", "~> 2.10.0"
+  s.add_development_dependency "rspec", "~> 2.11.0"
   s.add_development_dependency "bundler", ">= 1.0.0"
   s.add_development_dependency "jeweler", "~> 1.6.4"
   s.add_development_dependency "bourne", "1.0"

--- a/spec/rollout_spec.rb
+++ b/spec/rollout_spec.rb
@@ -286,21 +286,21 @@ describe "Rollout" do
     end
     it "saves the collection" do
       @rollout.define_id_collection(:my_collection, [101, 102])
-      @rollout.collections.size.should == 2
+      expect(@rollout.collections).to have(2).items
     end
 
     it "is active if the feature is active for a user in a collection" do
       @rollout.add_collection_to_feature(:beta_testers, :my_feature)
-      @rollout.should be_active(:my_feature, 101)
+      expect(@rollout).to be_active(:my_feature, 101)
     end
 
     it "is not active if the feature is not active user outside a collection" do
       @rollout.add_collection_to_feature(:beta_testers, :my_feature)
-      @rollout.should_not be_active(:my_feature, 102)
+      expect(@rollout).to_not be_active(:my_feature, 102)
     end
 
     it "retrieves all ids from a specific collection" do
-      @rollout.ids_from_collection(:beta_testers).should == %w[101 103]
+      expect(@rollout.ids_from_collection(:beta_testers)).to eq %w[101 103]
     end
 
   end

--- a/spec/rollout_spec.rb
+++ b/spec/rollout_spec.rb
@@ -300,7 +300,7 @@ describe "Rollout" do
     end
 
     it "retrieves all ids from a specific collection" do
-      @rollout.ids_from_collection(:beta_testers).should == ["101", "103"]
+      @rollout.ids_from_collection(:beta_testers).should == %w[101 103]
     end
 
   end

--- a/spec/rollout_spec.rb
+++ b/spec/rollout_spec.rb
@@ -280,6 +280,31 @@ describe "Rollout" do
     end
   end
 
+  describe "id collections" do
+    before do
+      @rollout.define_id_collection(:beta_testers, [101, 103])
+    end
+    it "saves the collection" do
+      @rollout.define_id_collection(:my_collection, [101, 102])
+      @rollout.collections.size.should == 2
+    end
+
+    it "is active if the feature is active for a user in a collection" do
+      @rollout.add_collection_to_feature(:beta_testers, :my_feature)
+      @rollout.should be_active(:my_feature, 101)
+    end
+
+    it "is not active if the feature is not active user outside a collection" do
+      @rollout.add_collection_to_feature(:beta_testers, :my_feature)
+      @rollout.should_not be_active(:my_feature, 102)
+    end
+
+    it "retrieves all ids from a specific collection" do
+      @rollout.ids_from_collection(:beta_testers).should == ["101", "103"]
+    end
+
+  end
+
   describe "#get" do
     before do
       @rollout.activate_percentage(:chat, 10)


### PR DESCRIPTION
@GonchuB, I changed and created a PR. Check it and tell me what you think.

About the rspec `expect` syntax, I commented with this on the commit:

I tried to use the expect syntax. But when I change it, I receive:

```
 Failure/Error: expect(@rollout.collections.size).to eq 2
 ArgumentError:
   wrong number of arguments (1 for 0)
```

A look into the rspec-expectations 2.10 documentation, and it shows to use the should.
http://www.relishapp.com/rspec/rspec-expectations/v/2-10/docs. Different from the actual one that shows to use expect http://www.relishapp.com/rspec/rspec-expectations/v/3-0/docs/.

This expect syntax was included on 2.11. 
http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/
Maybe we can upgrade it. What you think?
