### PR TITLE
Fix deprecation warnings on Ruby 2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 services:
   - redis-server
 rvm:
+  - 2.4
   - 2.1
   - 2.0.0
   - 1.9.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ GEM
     mocha (0.9.8)
       rake
     rake (0.9.2.2)
-    redis (3.0.7)
+    redis (4.0.1)
     rspec (2.11.0)
       rspec-core (~> 2.11.0)
       rspec-expectations (~> 2.11.0)
@@ -38,3 +38,6 @@ DEPENDENCIES
   redis
   rollout!
   rspec (~> 2.11.0)
+
+BUNDLED WITH
+   1.15.4

--- a/lib/rollout.rb
+++ b/lib/rollout.rb
@@ -68,7 +68,7 @@ class Rollout
 
     private
       def user_id(user)
-        if user.is_a?(Fixnum) ||
+        if user.is_a?(Integer) ||
              user.is_a?(String)
           user.to_s
         else


### PR DESCRIPTION
I tried updating the code with upstream (https://github.com/fetlife/rollout), which already has these fixes, and although the merge conflics seemed easy to solve, the test suite broke. 

I don't consider it worth it maintaining upstream compatibility on this fork, so i'm just submitting the fixes for some Ruby 2.4 deprecation warnings, specifically:

- Use Integer instead of Fixnum (Fixnum and Bignum were deprecated)
- And update the redis client, which was also triggering a similar Fixnum deprecation warning